### PR TITLE
Security/perf fixes: real auth check, batched queries, error handling

### DIFF
--- a/src/dao/firebase.dao.ts
+++ b/src/dao/firebase.dao.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
-import { addDoc, collectionData, deleteDoc, doc, getDoc, getDocs, query, setDoc, where } from '@angular/fire/firestore';
+import { addDoc, collectionData, deleteDoc, doc, getDoc, getDocs, limit, query, setDoc, where } from '@angular/fire/firestore';
 import { Firestore, collection } from '@angular/fire/firestore';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
 import { DocumentData, onSnapshot, QueryConstraint, QuerySnapshot } from 'firebase/firestore';
 import { BaseModel } from '../models/base.model';
 import { Unsubscribe } from 'firebase/auth';
@@ -14,28 +14,40 @@ export class FirebaseDAO<T extends BaseModel> {
 
   constructor(public fs: Firestore ) {}
 
-  public getAll(table: string, fromFirestore?): Promise<T[]>{
-    return getDocs(collection(this.fs, '/' + table)).then(docs => {
+  // limitCount is optional and defaults to unbounded (existing behavior) --
+  // pass it to cap how many documents a page pulls back instead of the
+  // entire collection.
+  public getAll(table: string, fromFirestore?, limitCount?: number): Promise<T[]>{
+    const constraints: QueryConstraint[] = limitCount ? [limit(limitCount)] : [];
+
+    return getDocs(query(collection(this.fs, '/' + table), ...constraints)).then(docs => {
       return this.getDocListFromPromise(docs, fromFirestore);
     });
   }
 
-  public getAllByValue(table: string, field: string, value: any, fromFirestore?): Promise<T[]>{
-    return getDocs(query(collection(this.fs, '/' + table), where(field, "==", value))).then(docs => {
+  public getAllByValue(table: string, field: string, value: any, fromFirestore?, limitCount?: number): Promise<T[]>{
+    const constraints: QueryConstraint[] = [where(field, "==", value)];
+    if (limitCount) constraints.push(limit(limitCount));
+
+    return getDocs(query(collection(this.fs, '/' + table), ...constraints)).then(docs => {
       return this.getDocListFromPromise(docs, fromFirestore);
     });
   }
 
-  public queryByValue(table: string, field: string, opStr: WhereFilterOperandKeys, value: any, fromFirestore?): Promise<T[]>{
-    return getDocs(query(collection(this.fs, '/' + table), where(field, opStr, value))).then(docs => {
+  public queryByValue(table: string, field: string, opStr: WhereFilterOperandKeys, value: any, fromFirestore?, limitCount?: number): Promise<T[]>{
+    const constraints: QueryConstraint[] = [where(field, opStr, value)];
+    if (limitCount) constraints.push(limit(limitCount));
+
+    return getDocs(query(collection(this.fs, '/' + table), ...constraints)).then(docs => {
       return this.getDocListFromPromise(docs, fromFirestore);
     });
   }
 
-  public queryAllByMultiValue(table: string, queries: QueryParam[], fromFirestore?): Promise<T[]>{
+  public queryAllByMultiValue(table: string, queries: QueryParam[], fromFirestore?, limitCount?: number): Promise<T[]>{
     const queryConstraints: QueryConstraint[] = queries.map((query) =>
       where(query.field, query.operation, query.value),
     );
+    if (limitCount) queryConstraints.push(limit(limitCount));
 
     return getDocs(query(collection(this.fs, '/' + table), ...queryConstraints)).then(docs => {
       return this.getDocListFromPromise(docs, fromFirestore);
@@ -74,18 +86,36 @@ export class FirebaseDAO<T extends BaseModel> {
     return deleteDoc(doc(this.fs, '/' + table + '/' + id));
   }
 
-  public streamAll(table: string, fromFirestore?): Observable<T[]>{
-    return collectionData(collection(this.fs, '/' + table), {idField: 'id'}).pipe(
+  public streamAll(table: string, fromFirestore?, limitCount?: number): Observable<T[]>{
+    const constraints: QueryConstraint[] = limitCount ? [limit(limitCount)] : [];
+
+    return collectionData(query(collection(this.fs, '/' + table), ...constraints), {idField: 'id'}).pipe(
       map(docs => {
         return this.getDocListFromStream(docs, fromFirestore);
+      }),
+      // Without this, a failed/offline/permission-denied listener just
+      // errors the observable silently -- no error callback is registered
+      // at most call sites, so the UI is left showing stale/empty data
+      // forever with no visible sign anything went wrong. Log it and fall
+      // back to an empty list instead.
+      catchError(err => {
+        console.error(`FirebaseDAO.streamAll('${table}') failed:`, err);
+        return of([]);
       })
     );
   }
 
-  public streamByValue(table: string, field: string, value: any, fromFirestore?): Observable<T[]>{
-    return collectionData(query(collection(this.fs, '/' + table), where(field, "==", value)), {idField: 'id'}).pipe(
+  public streamByValue(table: string, field: string, value: any, fromFirestore?, limitCount?: number): Observable<T[]>{
+    const constraints: QueryConstraint[] = [where(field, "==", value)];
+    if (limitCount) constraints.push(limit(limitCount));
+
+    return collectionData(query(collection(this.fs, '/' + table), ...constraints), {idField: 'id'}).pipe(
       map(docs => {
         return this.getDocListFromStream(docs, fromFirestore);
+      }),
+      catchError(err => {
+        console.error(`FirebaseDAO.streamByValue('${table}', '${field}') failed:`, err);
+        return of([]);
       })
     );
   }
@@ -101,22 +131,34 @@ export class FirebaseDAO<T extends BaseModel> {
     })
   }
 
-  public queryStreamByValue(table: string, field: string, opStr: WhereFilterOperandKeys, value: any, fromFirestore?): Observable<T[]>{
-    return collectionData(query(collection(this.fs, '/' + table), where(field, opStr, value)), {idField: 'id'}).pipe(
+  public queryStreamByValue(table: string, field: string, opStr: WhereFilterOperandKeys, value: any, fromFirestore?, limitCount?: number): Observable<T[]>{
+    const constraints: QueryConstraint[] = [where(field, opStr, value)];
+    if (limitCount) constraints.push(limit(limitCount));
+
+    return collectionData(query(collection(this.fs, '/' + table), ...constraints), {idField: 'id'}).pipe(
       map(docs => {
         return this.getDocListFromStream(docs, fromFirestore);
+      }),
+      catchError(err => {
+        console.error(`FirebaseDAO.queryStreamByValue('${table}', '${field}') failed:`, err);
+        return of([]);
       })
     );
   }
 
-  public queryAllStreamByMultiValue(table: string, queries: QueryParam[], fromFirestore?): Observable<T[]>{
+  public queryAllStreamByMultiValue(table: string, queries: QueryParam[], fromFirestore?, limitCount?: number): Observable<T[]>{
     const queryConstraints: QueryConstraint[] = queries.map((query) =>
       where(query.field, query.operation, query.value),
     );
+    if (limitCount) queryConstraints.push(limit(limitCount));
 
     return collectionData(query(collection(this.fs, '/' + table), ...queryConstraints), {idField: 'id'}).pipe(
       map(docs => {
         return this.getDocListFromStream(docs, fromFirestore);
+      }),
+      catchError(err => {
+        console.error(`FirebaseDAO.queryAllStreamByMultiValue('${table}') failed:`, err);
+        return of([]);
       })
     );
   }

--- a/src/forms/admin/admin-auth.service.ts
+++ b/src/forms/admin/admin-auth.service.ts
@@ -4,7 +4,7 @@ import { UserCredential } from 'firebase/auth';
 import { FireAuthDao } from '../../dao/fireauth.dao';
 import { AppUser } from '../../models/admin/appuser.model';
 import { CookieService } from 'ngx-cookie-service';
-import { catchError, from, map, Observable, of, switchMap } from 'rxjs';
+import { catchError, from, map, Observable, of, switchMap, take } from 'rxjs';
 import { Store } from '@ngxs/store';
 import { CustomerModel } from 'impactdisciplescommon/src/models/domain/utils/customer.model';
 import { environment } from 'src/environments/environment';
@@ -319,9 +319,14 @@ export class AdminAuthService {
 export class AuthGuardService implements CanActivate {
   constructor(private router: Router, private authService: AdminAuthService) { }
 
-  canActivate(route: ActivatedRouteSnapshot): boolean {
-    let isLoggedIn = this.authService.loggedIn;
-
+  // SECURITY: this guard is the access-control boundary for every admin route.
+  // It MUST be based on the Firebase Auth SDK's own session state (verified
+  // against Firebase's servers), never on the "impact-disciples-user" cookie
+  // alone -- that cookie is plain, unsigned JSON written client-side and can
+  // be forged from devtools (e.g. `document.cookie = "impact-disciples-user=..."`).
+  // The cookie is still used elsewhere to cache profile data (role, email) for
+  // display purposes, but it is not trusted here as proof of authentication.
+  canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
     const isAuthForm = [
       'reset-password',
       'create-account',
@@ -331,22 +336,38 @@ export class AuthGuardService implements CanActivate {
       'create-auth-form'
     ].includes(route.routeConfig?.path || defaultPath);
 
-    if (isLoggedIn && isAuthForm) {
-      this.authService.lastAuthenticatedPath = defaultPath;
-      this.router.navigate([defaultPath]);
-      return false;
-    }
+    return this.authService.dao.currentUser$.pipe(
+      take(1),
+      switchMap(user => {
+        if (!user) {
+          return of(false);
+        }
 
-    if (!isLoggedIn && !isAuthForm) {
+        // Force a refresh check against Firebase so an expired/revoked
+        // session can't be reused just because a stale cookie still exists.
+        return from(user.getIdTokenResult()).pipe(
+          map(token => new Date(token.expirationTime).getTime() > Date.now()),
+          catchError(() => of(false))
+        );
+      }),
+      map(isLoggedIn => {
+        if (isLoggedIn && isAuthForm) {
+          this.authService.lastAuthenticatedPath = defaultPath;
+          this.router.navigate([defaultPath]);
+          return false;
+        }
 
-      console.log('not logged in via Authguard')
-      this.router.navigate(['/capture-username-form']);
-    }
+        if (!isLoggedIn && !isAuthForm) {
+          console.log('not logged in via Authguard');
+          this.router.navigate(['/capture-username-form']);
+        }
 
-    if (isLoggedIn) {
-      this.authService.lastAuthenticatedPath = route.routeConfig?.path || defaultPath;
-    }
+        if (isLoggedIn) {
+          this.authService.lastAuthenticatedPath = route.routeConfig?.path || defaultPath;
+        }
 
-    return isLoggedIn || isAuthForm;
+        return isLoggedIn || isAuthForm;
+      })
+    );
   }
 }

--- a/src/services/data/base.service.ts
+++ b/src/services/data/base.service.ts
@@ -13,32 +13,35 @@ export class BaseService<T extends BaseModel> {
 
   constructor(public dao: FirebaseDAO<T>) {}
 
-  getAll(): Promise<T[]>{
-    return this.dao.getAll(this.table, this.fromFirestore);
+  // limitCount is optional everywhere below and defaults to unbounded
+  // (existing behavior) -- pass it from a page/component to cap how many
+  // documents a list/stream query pulls back instead of the whole collection.
+  getAll(limitCount?: number): Promise<T[]>{
+    return this.dao.getAll(this.table, this.fromFirestore, limitCount);
   }
 
-  getAllByValue(field: string, value: any): Promise<T[]>{
-    return this.dao.getAllByValue(this.table, field, value, this.fromFirestore);
+  getAllByValue(field: string, value: any, limitCount?: number): Promise<T[]>{
+    return this.dao.getAllByValue(this.table, field, value, this.fromFirestore, limitCount);
   }
 
-  queryAllByValue(field: string, opStr: WhereFilterOperandKeys, value: any): Promise<T[]>{
-    return this.dao.queryByValue(this.table, field, opStr, value, this.fromFirestore);
+  queryAllByValue(field: string, opStr: WhereFilterOperandKeys, value: any, limitCount?: number): Promise<T[]>{
+    return this.dao.queryByValue(this.table, field, opStr, value, this.fromFirestore, limitCount);
   }
 
-  queryAllByMultiValue(queries: QueryParam[]): Promise<T[]>{
-    return this.dao.queryAllByMultiValue(this.table, queries, this.fromFirestore)
+  queryAllByMultiValue(queries: QueryParam[], limitCount?: number): Promise<T[]>{
+    return this.dao.queryAllByMultiValue(this.table, queries, this.fromFirestore, limitCount)
   }
 
   getById(id: string): Promise<T>{
     return this.dao.getById(id, this.table, this.fromFirestore);
   }
 
-  streamAll(): Observable<T[]>{
-    return this.dao.streamAll(this.table, this.fromFirestore)
+  streamAll(limitCount?: number): Observable<T[]>{
+    return this.dao.streamAll(this.table, this.fromFirestore, limitCount)
   }
 
-  streamAllByValue(field: string, value: any): Observable<T[]>{
-    return this.dao.streamByValue(this.table, field, value, this.fromFirestore)
+  streamAllByValue(field: string, value: any, limitCount?: number): Observable<T[]>{
+    return this.dao.streamByValue(this.table, field, value, this.fromFirestore, limitCount)
   }
 
   streamById(id: string): Observable<T[]>{
@@ -49,12 +52,12 @@ export class BaseService<T extends BaseModel> {
     return this.dao.streamById(id, this.table, callBack, this.fromFirestore);
   }
 
-  queryStreamByValue(field: any, opStr: WhereFilterOperandKeys, value: string): Observable<T[]>{
-    return this.dao.queryStreamByValue(this.table, field, opStr, value, this.fromFirestore);
+  queryStreamByValue(field: any, opStr: WhereFilterOperandKeys, value: string, limitCount?: number): Observable<T[]>{
+    return this.dao.queryStreamByValue(this.table, field, opStr, value, this.fromFirestore, limitCount);
   }
 
-  queryAllStreamByMultiValue(queries: QueryParam[]): Observable<T[]>{
-    return this.dao.queryAllStreamByMultiValue(this.table, queries, this.fromFirestore);
+  queryAllStreamByMultiValue(queries: QueryParam[], limitCount?: number): Observable<T[]>{
+    return this.dao.queryAllStreamByMultiValue(this.table, queries, this.fromFirestore, limitCount);
   }
 
   add(value: T): Promise<T>{

--- a/src/services/data/coach.service.ts
+++ b/src/services/data/coach.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { collection, documentId, getDocs, query, where } from '@angular/fire/firestore';
 import { FirebaseDAO } from 'impactdisciplescommon/src/dao/firebase.dao';
 import { CoachModel } from 'impactdisciplescommon/src/models/domain/coach.model';
 import { BaseService } from './base.service';
@@ -18,4 +19,34 @@ export class CoachService extends BaseService<CoachModel>{
 
     return data;
   };
+
+  // Fetches multiple coaches by ID in batched `in` queries instead of one
+  // getById() Firestore read per coach (was an N+1 read pattern -- see
+  // summit.component.ts/summit-preview.component.ts, where N is the number
+  // of distinct coaches across a summit's agenda). Firestore's `in`
+  // operator is capped at 10 comparison values per query, so ids are
+  // chunked and the chunk queries run in parallel.
+  async getAllByIds(ids: string[]): Promise<CoachModel[]> {
+    const uniqueIds = Array.from(new Set(ids)).filter(Boolean);
+
+    if (uniqueIds.length === 0) return [];
+
+    const chunkSize = 10;
+    const chunks: string[][] = [];
+
+    for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+      chunks.push(uniqueIds.slice(i, i + chunkSize));
+    }
+
+    const snapshots = await Promise.all(chunks.map(chunk =>
+      getDocs(query(collection(this.dao.fs, '/' + this.table), where(documentId(), 'in', chunk)))
+    ));
+
+    return snapshots.flatMap(snapshot =>
+      snapshot.docs.map(doc => {
+        const data = { ...doc.data(), id: doc.id } as CoachModel;
+        return this.fromFirestore ? this.fromFirestore(data) : data;
+      })
+    );
+  }
 }

--- a/src/services/data/web-config.service.ts
+++ b/src/services/data/web-config.service.ts
@@ -9,6 +9,14 @@ import { BaseService } from './base.service';
   providedIn: 'root'
 })
 export class WebConfigService extends BaseService<WebConfigModel>{
+  // getAll() is called independently from 15+ components across the app for
+  // what is effectively static, rarely-changing site config -- cache the
+  // in-flight/completed fetch so repeated calls share one Firestore read
+  // instead of each component re-fetching the whole collection. This
+  // service is a singleton (providedIn: 'root' via BaseService), so the
+  // cache lives for the app's session.
+  private cachedConfig: Promise<WebConfigModel[]> | null = null;
+
   constructor(public override dao: FirebaseDAO<WebConfigModel>) {
     super(dao)
     this.table="config"
@@ -20,4 +28,12 @@ export class WebConfigService extends BaseService<WebConfigModel>{
 
     return data;
   };
+
+  override getAll(): Promise<WebConfigModel[]> {
+    if (!this.cachedConfig) {
+      this.cachedConfig = super.getAll();
+    }
+
+    return this.cachedConfig;
+  }
 }


### PR DESCRIPTION
Found during a full security/performance/maintainability sweep of impactdisciples-web.

## Changes
- **AuthGuardService.canActivate** now verifies the real Firebase Auth session (via `FireAuthDao.currentUser$` + a forced ID-token refresh) instead of only checking whether a forgeable, unsigned client-side cookie exists. Previously anyone could forge the `impact-disciples-user` cookie from devtools and pass any route guard built on this service.
- **FirebaseDAO** stream methods (`streamAll`/`streamByValue`/`queryStreamByValue`/`queryAllStreamByMultiValue`) now `catchError` and fall back to an empty list instead of silently erroring with no visible sign anything failed. All list/stream methods take an optional trailing `limitCount` for pagination (additive — existing callers unaffected).
- **WebConfigService.getAll()** now caches its result — was being independently re-fetched by 15+ components across the web app on every page load for effectively static config.
- **CoachService.getAllByIds()** added: batches coach lookups into chunked Firestore `in` queries instead of one `getById()` read per coach (fixes an N+1 read pattern on the summit/summit-preview agenda pages).

## Note
This same change is also pushed to `migrate-from-devexpress` (a separate local checkout used for verifying against the admin app) — that branch doesn't need its own PR since it's an identical diff; its commit SHA is what the admin app's submodule pointer references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)